### PR TITLE
Use go 1.17 to build choria

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,8 @@
 brew tap bigcommerce/choria
 brew install choria
 ```
+
+## Making changes
+
+If you need to update the formula, run `brew edit choria` to edit it. To test the changes, run `brew upgrade choria`. You can create a branch and submit a PR after testing the changes.
+

--- a/choria.rb
+++ b/choria.rb
@@ -11,10 +11,10 @@ class Choria < Formula
     strategy :github_latest
   end
 
-  depends_on "go" => :build
+  depends_on "go@1.17" => :build
 
   def install
-    system "go", "build", *std_go_args(ldflags: "-s -w"), "-o", bin/"choria", "main.go"
+    system Formula["go@1.17"].opt_prefix/"bin/go", "build", *std_go_args(ldflags: "-s -w"), "-o", bin/"choria", "main.go"
   end
 
   test do


### PR DESCRIPTION
Does what the title says since Choria 0.24.1 doesn't build with go 1.18.

ping @rayward 