### PR TITLE
Package choria 0.27.0 with go 1.20

### DIFF
--- a/choria.rb
+++ b/choria.rb
@@ -1,8 +1,8 @@
 class Choria < Formula
   desc "Orchestration System with roots in The Marionette Collective"
   homepage "https://choria.io/"
-  url "https://github.com/choria-io/go-choria/archive/refs/tags/v0.24.1.tar.gz"
-  sha256 "7d869b0b84b01582f4b1e1730fac32eb66b6bfe56726ef458370a0e72134ca88"
+  url "https://github.com/choria-io/go-choria/archive/refs/tags/v0.27.0.tar.gz"
+  sha256 "e8725acf899414980b92175a48844aefea3001044ba6273d4aaea93ac2a896c5"
   license "Apache-2.0"
   head "https://github.com/choria-io/go-choria.git", branch: "main"
 
@@ -11,10 +11,10 @@ class Choria < Formula
     strategy :github_latest
   end
 
-  depends_on "go@1.17" => :build
+  depends_on "go@1.20" => :build
 
   def install
-    system Formula["go@1.17"].opt_prefix/"bin/go", "build", *std_go_args(ldflags: "-s -w"), "-o", bin/"choria", "main.go"
+    system Formula["go@1.20"].opt_prefix/"bin/go", "build", *std_go_args(ldflags: "-s -w"), "-o", bin/"choria", "main.go"
   end
 
   test do


### PR DESCRIPTION
I wasn't able to build v0.24 with Go 1.17 on my arm64 Mac with MacOS Sonoma. The version of Choira and Go are pretty old, so bumping both to the latest.

This builds:

```
$ brew install choria
==> Fetching dependencies for bigcommerce/choria/choria: go@1.20
==> Fetching go@1.20
==> Downloading https://ghcr.io/v2/homebrew/core/go/1.20/manifests/1.20.12
Already downloaded: /Users/chris/Library/Caches/Homebrew/downloads/1780446a0530be714935510f333fcc011cceda3825482a7974a388467bf0a5fa--go@1.20-1.20.12.bottle_manifest.json
==> Downloading https://ghcr.io/v2/homebrew/core/go/1.20/blobs/sha256:7c142abdda3f381d8520334669a15864062b82a0382f32ed383cf146f2c71c3c
Already downloaded: /Users/chris/Library/Caches/Homebrew/downloads/6443834af44056f15d71eb2120cc93b22ce669c89eb6b0ae577b382b3bc94021--go@1.20--1.20.12.arm64_sonoma.bottle.tar.gz
==> Fetching bigcommerce/choria/choria
==> Downloading https://github.com/choria-io/go-choria/archive/refs/tags/v0.27.0.tar.gz
Already downloaded: /Users/chris/Library/Caches/Homebrew/downloads/eb798683b3841375134dd4a9d9935eeddced81a0c2f8424fc7545a866152f262--go-choria-0.27.0.tar.gz
==> Installing choria from bigcommerce/choria
==> Installing dependencies for bigcommerce/choria/choria: go@1.20
==> Installing bigcommerce/choria/choria dependency: go@1.20
==> Downloading https://ghcr.io/v2/homebrew/core/go/1.20/manifests/1.20.12
Already downloaded: /Users/chris/Library/Caches/Homebrew/downloads/1780446a0530be714935510f333fcc011cceda3825482a7974a388467bf0a5fa--go@1.20-1.20.12.bottle_manifest.json
==> Pouring go@1.20--1.20.12.arm64_sonoma.bottle.tar.gz
🍺  /opt/homebrew/Cellar/go@1.20/1.20.12: 12,003 files, 233.5MB
==> Installing bigcommerce/choria/choria
==> /opt/homebrew/opt/go@1.20/bin/go build -trimpath -o=/opt/homebrew/Cellar/choria/0.27.0/bin/choria -ldflags=-s -w -o /opt/homebrew/Cellar/choria/0.27.0/bin/choria main.go
🍺  /opt/homebrew/Cellar/choria/0.27.0: 7 files, 38.3MB, built in 16 seconds
==> Running `brew cleanup choria`...
Disable this behaviour by setting HOMEBREW_NO_INSTALL_CLEANUP.
Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).
```

choria ping, facts, other discovery commands work.