### PR TITLE
Build choria 0.29.1

### DIFF
--- a/choria.rb
+++ b/choria.rb
@@ -1,8 +1,8 @@
 class Choria < Formula
   desc "Orchestration System with roots in The Marionette Collective"
   homepage "https://choria.io/"
-  url "https://github.com/choria-io/go-choria/archive/refs/tags/v0.27.0.tar.gz"
-  sha256 "e8725acf899414980b92175a48844aefea3001044ba6273d4aaea93ac2a896c5"
+  url "https://github.com/choria-io/go-choria/archive/refs/tags/v0.29.1.tar.gz"
+  sha256 "b2a5e8720e4ff6927d176f5d1c0eed394ce05c26ad174e680b5be2d4dcdc0fe8"
   license "Apache-2.0"
   head "https://github.com/choria-io/go-choria.git", branch: "main"
 
@@ -11,10 +11,10 @@ class Choria < Formula
     strategy :github_latest
   end
 
-  depends_on "go@1.20" => :build
+  depends_on "go@1.21" => :build
 
   def install
-    system Formula["go@1.20"].opt_prefix/"bin/go", "build", *std_go_args(ldflags: "-s -w"), "-o", bin/"choria", "main.go"
+    system Formula["go@1.21"].opt_prefix/"bin/go", "build", *std_go_args(ldflags: "-s -w"), "-o", bin/"choria", "main.go"
   end
 
   test do


### PR DESCRIPTION
```
==> Fetching bigcommerce/choria/choria
==> Downloading https://github.com/choria-io/go-choria/archive/refs/tags/v0.29.1.tar.gz
Already downloaded: /Users/chris/Library/Caches/Homebrew/downloads/f1925b7ebd8c6d2310fa6eaa68e4f8231ca4b25d7bac4c55658bbfef3eea5efa--go-choria-0.29.1.tar.gz
==> Upgrading bigcommerce/choria/choria
  0.27.0 -> 0.29.1 
==> Installing dependencies for bigcommerce/choria/choria: go@1.21
==> Installing bigcommerce/choria/choria dependency: go@1.21
==> Downloading https://ghcr.io/v2/homebrew/core/go/1.21/manifests/1.21.12
Already downloaded: /Users/chris/Library/Caches/Homebrew/downloads/2331b31ebce664d008df62c60c405005a579f73b53c7beadb28d583c4bb10f74--go@1.21-1.21.12.bottle_manifest.json
==> Verifying attestation for go@1.21
==> Pouring go@1.21--1.21.12.arm64_sonoma.bottle.tar.gz
🍺  /opt/homebrew/Cellar/go@1.21/1.21.12: 12,559 files, 241.4MB
==> Installing bigcommerce/choria/choria
==> /opt/homebrew/opt/go@1.21/bin/go build -trimpath -o=/opt/homebrew/Cellar/choria/0.29.1/bin/choria -ldflags=-s -w -o /opt/homebrew/Cellar/choria/0.29.1/bin/choria main.go
🍺  /opt/homebrew/Cellar/choria/0.29.1: 8 files, 42.7MB, built in 24 seconds
```

choria ping etc seem functional against our existing env.